### PR TITLE
Don't stop parsing on blank lines

### DIFF
--- a/lib/ConfigReader/Simple.pm
+++ b/lib/ConfigReader/Simple.pm
@@ -131,7 +131,7 @@ line. These three entries are the same:
 	from \
 	Peru
 
-If a line is only whitespace, or the first whitespace character is
+If a line is only whitespace, or the first non-whitespace character is
 a #, the Perl comment character, C<ConfigReader::Simple> ignores the
 line unless it is the continuation of the previous line.
 

--- a/lib/ConfigReader/Simple.pm
+++ b/lib/ConfigReader/Simple.pm
@@ -400,7 +400,7 @@ sub parse_string {
 	chomp( @lines );
 #	carp "A: Found " . @lines . " lines" if $DEBUG;
 
-	while( my $line = shift @lines ) {
+	while( defined( my $line = shift @lines )) {
 #		carp "1: Line is $line" if $DEBUG;
 
 		CONT: {

--- a/t/parse_string.t
+++ b/t/parse_string.t
@@ -16,6 +16,7 @@ can_ok( $class, $method );
 #
 {
 my $string = <<"HERE";
+
 cat Buster
 dog \\
 	Tuffy


### PR DESCRIPTION
Also slightly modify test suite to also test this case by adding a leading blank line to the tested example string.

Fixes #2

Additionally fix missing negation in documentation (whitespace vs non-whitespace) in a separate commit. As mentioned in #2.